### PR TITLE
updates client samples url paths in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,5 +24,5 @@ The Cisco Cloud Security development client samples, scripts, applications, Post
 [**Client Code Samples**](https://github.com/CiscoDevNet/cloud-security/tree/master/client-samples/README.md)
 * [**Go**](https://github.com/CiscoDevNet/cloud-security/tree/master/client-samples/golang/)
 * [**Java**](https://github.com/CiscoDevNet/cloud-security/tree/master/client-samples/java/)
-* [**PHP**](https://github.com/CiscoDevNet/cloud-security/tree/master/php/)
-* [**Python**](https://github.com/CiscoDevNet/cloud-security/tree/master/python/)
+* [**PHP**](https://github.com/CiscoDevNet/cloud-security/tree/master/client-samples/php/)
+* [**Python**](https://github.com/CiscoDevNet/cloud-security/tree/master/client-samples/python/)


### PR DESCRIPTION
This PR fixes the URL path for PHP and Python client code samples in the root Readme.