### PR TITLE
Fix a typo that lead to invalid code in the python requests client

### DIFF
--- a/client-samples/python/requests_api_sample_client.py
+++ b/client-samples/python/requests_api_sample_client.py
@@ -41,7 +41,7 @@ class UmbrellaAPI():
 			return None
 		else:
 			clock_skew = 300
-			self.access_token_expiration = int(time.time()) + rsp.expires_in - clock_skew
+			self.access_token_expiration = int(time.time()) + rsp.json()['expires_in'] - clock_skew
 			return rsp.json()['access_token']
 
 	def __str__(self):


### PR DESCRIPTION
In the example, res.expires_in was accessed but that field does not exist in a Response object.
An alternative that works and gives the desired result is res.json()['expires_in']