### PR TITLE
Fix the refreshToken decorator

### DIFF
--- a/client-samples/python/requests_api_sample_client.py
+++ b/client-samples/python/requests_api_sample_client.py
@@ -41,7 +41,7 @@ class UmbrellaAPI():
 			return None
 		else:
 			clock_skew = 300
-			self.access_token_expiration = int(time.time()) + rsp.expires_in - clock_skew
+			self.access_token_expiration = int(time.time()) + rsp.json()['expires_in'] - clock_skew
 			return rsp.json()['access_token']
 
 	def __str__(self):

--- a/client-samples/python/requests_api_sample_client.py
+++ b/client-samples/python/requests_api_sample_client.py
@@ -50,7 +50,7 @@ class UmbrellaAPI():
 def refreshToken(decorated):
 	def wrapper(api, *args, **kwargs):
 		if int(time.time()) > api.access_token_expiration:
-			api.getAccessToken()
+			api.access_token = api.getAccessToken()
 		return decorated(api, *args, **kwargs)
 	return wrapper
 


### PR DESCRIPTION
After calling the getAccessToken method, the resulting token was not stored by the caller function (from the decorator) nor was it stored by the getAccessToken method itself.
This resulted in the refresh function not working properly. This could lead to some bugs that could be discovered only after leaving the application idle until the token expires if someone tries to use the decorator from this example.